### PR TITLE
Bump danger to support version 6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     danger-duplicate_localizable_strings (0.0.2)
-      danger (~> 5.5)
+      danger (~> 6.0)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
Currently danger has new version 6.0 but this framework doesn't support this version anymore.